### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-debug-this.yml
+++ b/.github/workflows/python-debug-this.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3.3.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.8
 
@@ -49,7 +49,7 @@ jobs:
       uses: actions/checkout@v3.3.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.4.0](https://github.com/actions/setup-python/releases/tag/v4.4.0)** on 2022-12-22T12:48:23Z
