### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Run GitHub Actions Version Updater
-      uses: saadmk11/github-actions-version-updater@v0.7.3
+      uses: saadmk11/github-actions-version-updater@v0.7.4
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         pull_request_branch: 'ghactions-autoupdate'

--- a/.github/workflows/python-debug-this.yml
+++ b/.github/workflows/python-debug-this.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
 
     - name: Set up Python
       uses: actions/setup-python@v4.5.0
@@ -29,14 +29,14 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.7.1
+      uses: pypa/gh-action-pypi-publish@v1.8.1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
-      uses: pypa/gh-action-pypi-publish@v1.7.1
+      uses: pypa/gh-action-pypi-publish@v1.8.1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
@@ -46,7 +46,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
 
     - name: Set up Python
       uses: actions/setup-python@v4.5.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.4](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.4)** on 2023-03-15T16:41:04Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.4.0](https://github.com/actions/checkout/releases/tag/v3.4.0)** on 2023-03-15T19:47:24Z
