### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.3
+      uses: actions/checkout@v3.6.0
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/python-debug-this.yml
+++ b/.github/workflows/python-debug-this.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.3
+      uses: actions/checkout@v3.6.0
 
     - name: Set up Python
       uses: actions/setup-python@v4.7.0
@@ -46,7 +46,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.3
+      uses: actions/checkout@v3.6.0
 
     - name: Set up Python
       uses: actions/setup-python@v4.7.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.6.0](https://github.com/actions/checkout/releases/tag/v3.6.0)** on 2023-08-24T13:56:41Z
