### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.1
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/python-debug-this.yml
+++ b/.github/workflows/python-debug-this.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4.7.0
+      uses: actions/setup-python@v5.0.0
       with:
         python-version: 3.8
 
@@ -29,14 +29,14 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+      uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+      uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
@@ -46,10 +46,10 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4.7.0
+      uses: actions/setup-python@v5.0.0
       with:
         python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
